### PR TITLE
Skip elite mixture on easy stages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # FastHier
 Fast hierarchical modeling
+
+## Elite mixture fitting
+
+The adaptive SMC sampler now skips elite mixture fitting when the difficulty
+estimate (`difficulty_ema`) falls below a threshold. This avoids unnecessary
+mixture updates on easy stages while re-enabling them once the difficulty
+rises again. The threshold defaults to `0.2` and can be tuned via the
+`mix_difficulty_threshold` argument in `enhanced_smc_elite()` or `auto_smc()`.


### PR DESCRIPTION
## Summary
- add `mix_difficulty_threshold` to control when elite mixture fitting is skipped
- reuse last elite mixture while difficulty is low and re-fit when difficulty rises
- document new elite mixture threshold option in README

## Testing
- `Rscript run_smc_example.R` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6894a569b7a4832abd7f8c79f7029e8a